### PR TITLE
Bug fix: Update `dynamodb.DynamoDBDeliveriesTable` schema to record multiple deliveries

### DIFF
--- a/database/confirmation_docstore.go
+++ b/database/confirmation_docstore.go
@@ -89,7 +89,7 @@ func (db *ConfirmationsDocstoreDatabase) getConfirmationWithQuery(ctx context.Co
 	if err == io.EOF {
 		return nil, NoRecordError("")
 	} else if err != nil {
-		return nil, fmt.Errorf("Failed to interate, %w", err)
+		return nil, fmt.Errorf("Failed to iterate, %w", err)
 	} else {
 		return &c, nil
 	}
@@ -108,7 +108,7 @@ func (db *ConfirmationsDocstoreDatabase) getConfirmationsWithCallback(ctx contex
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("Failed to interate, %w", err)
+			return fmt.Errorf("Failed to iterate, %w", err)
 		} else {
 
 			err := cb(ctx, &c)

--- a/database/deliveries_docstore.go
+++ b/database/deliveries_docstore.go
@@ -83,7 +83,7 @@ func (db *DeliveriesDocstoreDatabase) getDeliveryWithQuery(ctx context.Context, 
 	if err == io.EOF {
 		return nil, NoRecordError("")
 	} else if err != nil {
-		return nil, fmt.Errorf("Failed to interate, %w", err)
+		return nil, fmt.Errorf("Failed to iterate, %w", err)
 	} else {
 		return &d, nil
 	}
@@ -102,7 +102,7 @@ func (db *DeliveriesDocstoreDatabase) getDeliveriesWithCallback(ctx context.Cont
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("Failed to interate, %w", err)
+			return fmt.Errorf("Failed to iterate, %w", err)
 		} else {
 
 			err := cb(ctx, &d)

--- a/database/eventlogs_docstore.go
+++ b/database/eventlogs_docstore.go
@@ -76,7 +76,7 @@ func (db *EventLogsDocstoreDatabase) getDeliveryWithQuery(ctx context.Context, q
 	if err == io.EOF {
 		return nil, NoRecordError("")
 	} else if err != nil {
-		return nil, fmt.Errorf("Failed to interate, %w", err)
+		return nil, fmt.Errorf("Failed to iterate, %w", err)
 	} else {
 		return &l, nil
 	}
@@ -95,7 +95,7 @@ func (db *EventLogsDocstoreDatabase) getEventLogsWithCallback(ctx context.Contex
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("Failed to interate, %w", err)
+			return fmt.Errorf("Failed to iterate, %w", err)
 		} else {
 
 			err := cb(ctx, &l)

--- a/database/invitations_docstore.go
+++ b/database/invitations_docstore.go
@@ -108,7 +108,7 @@ func (db *InvitationsDocstoreDatabase) getInvitationWithQuery(ctx context.Contex
 	if err == io.EOF {
 		return nil, NoRecordError("")
 	} else if err != nil {
-		return nil, fmt.Errorf("Failed to interate, %w", err)
+		return nil, fmt.Errorf("Failed to iterate, %w", err)
 	} else {
 		return &iv, nil
 	}
@@ -127,7 +127,7 @@ func (db *InvitationsDocstoreDatabase) getInvitationsWithCallback(ctx context.Co
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("Failed to interate, %w", err)
+			return fmt.Errorf("Failed to iterate, %w", err)
 		} else {
 
 			err := cb(ctx, &iv)

--- a/database/subscriptions_docstore.go
+++ b/database/subscriptions_docstore.go
@@ -96,7 +96,7 @@ func (db *SubscriptionsDocstoreDatabase) getSubscriptionWithQuery(ctx context.Co
 	if err == io.EOF {
 		return nil, NoRecordError("")
 	} else if err != nil {
-		return nil, fmt.Errorf("Failed to interate, %w", err)
+		return nil, fmt.Errorf("Failed to iterate, %w", err)
 	} else {
 		return &s, nil
 	}
@@ -121,7 +121,7 @@ func (db *SubscriptionsDocstoreDatabase) getSubscriptionsWithCallback(ctx contex
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("Failed to interate, %w", err)
+			return fmt.Errorf("Failed to iterate, %w", err)
 		} else {
 
 			err := cb(ctx, &s)

--- a/dynamodb/deliveries.go
+++ b/dynamodb/deliveries.go
@@ -16,20 +16,32 @@ var DynamoDBDeliveriesTable = &dynamodb.CreateTableInput{
 			AttributeName: aws.String("MessageId"),
 			AttributeType: "S",
 		},
+		{
+			AttributeName: aws.String("Delivered"),
+			AttributeType: "N",
+		},
 	},
 	KeySchema: []types.KeySchemaElement{
 		{
 			AttributeName: aws.String("Address"),
 			KeyType:       "HASH",
 		},
+		{
+			AttributeName: aws.String("Delivered"),
+			KeyType:       "RANGE",
+		},
 	},
 	GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 		{
-			IndexName: aws.String("message_id"),
+			IndexName: aws.String("address_message"),
 			KeySchema: []types.KeySchemaElement{
 				{
-					AttributeName: aws.String("MessageId"),
+					AttributeName: aws.String("Address"),
 					KeyType:       "HASH",
+				},
+				{
+					AttributeName: aws.String("MessageId"),
+					KeyType:       "RANGE",
 				},
 			},
 			Projection: &types.Projection{


### PR DESCRIPTION
* Bug fix: Update `dynamodb.DynamoDBDeliveriesTable` schema to record multiple deliveries. This will require deleting and recreating any existing `deliveries` tables.
* Fix typos when signaling iteration errors.